### PR TITLE
Standardized locale names

### DIFF
--- a/locale/es_ES/locale.xml
+++ b/locale/es_ES/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings
   -->
 
-<locale name="es_ES" full_name="Español">
+<locale name="es_ES" full_name="Español (España)">
 	<message key="plugins.generic.pdfJsViewer.name">Plugin visor de PDFs  PDF.JS</message>
 	<message key="plugins.generic.pdfJsViewer.description"><![CDATA[Este plugin usa el visor de PDFs <a href="http://mozilla.github.io/pdf.js"> pdf.js </a> para visualizar PDFs embebidos en las páginas de galerada de números y artículos.]]></message>
 </locale>

--- a/locale/fr_FR/locale.xml
+++ b/locale/fr_FR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings
   -->
 
-<locale name="fr_FR" full_name="Français (Canada)">
+<locale name="fr_FR" full_name="Français (France)">
 	<message key="plugins.generic.pdfJsViewer.name">Plugicie PDF.JS l visionneuse de PDF</message>
 	<message key="plugins.generic.pdfJsViewer.description"><![CDATA[Ce plugin utilise la <a href="http://mozilla.github.io/pdf.js">visionneuse de PDF</a> qui embarque les fichiers PDF de l'article et les pages de visualisation des épreuves.]]></message>
 </locale>

--- a/locale/it_IT/locale.xml
+++ b/locale/it_IT/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings
   -->
 
-<locale name="it_IT" full_name="Italian">
+<locale name="it_IT" full_name="Italiano">
 	<message key="plugins.generic.pdfJsViewer.name">Visualizzatore PDF.JS</message>
 	<message key="plugins.generic.pdfJsViewer.description"><![CDATA[Questo plugin utilizza <a href="http://mozilla.github.io/pdf.js">pdf.js PDF viewer</a> per visualizzare i PDF nelle pagine degli articoli e dei fascioli.]]></message>
 </locale>

--- a/locale/ru_RU/locale.xml
+++ b/locale/ru_RU/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2014 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   * Translated by Pavel Pisklakov. 
   -->
 
-<locale name="ru_RU" full_name="Russian">
+<locale name="ru_RU" full_name="Русский">
 	<message key="plugins.generic.pdfJsViewer.name">Плагин «PDF-просмотрщик PDF.JS»</message>
 	<message key="plugins.generic.pdfJsViewer.description"><![CDATA[Этот плагин использует <a href="http://mozilla.github.io/pdf.js">PDF-просмотрщик pdf.js</a> для встраивания PDF-файлов на страницы просмотра гранок статьи и выпуска.]]></message>
 </locale>


### PR DESCRIPTION
Following the recent standardization of locale names in the PKP applications, this tackles the pdfJsViewer plugin.