### PR TITLE
Harmonize de_DE locale with the ojs locale

### DIFF
--- a/locale/de_DE/locale.xml
+++ b/locale/de_DE/locale.xml
@@ -12,6 +12,6 @@
   -->
 
 <locale name="de_DE" full_name="Deutsch (Deutschland)">
-	<message key="plugins.generic.pdfJsViewer.name">PDF.JS-PDF-Viewer-Plug-In</message>
-	<message key="plugins.generic.pdfJsViewer.description"><![CDATA[Dieses Plug-In benutzt den <a href="http://mozilla.github.io/pdf.js">pdf.js PDF viewer</a>, um PDFs auf den Fahnenseiten von Artikeln und Ausgaben anzuzeigen.]]></message>
+	<message key="plugins.generic.pdfJsViewer.name">PDF.JS-PDF-Viewer-Plugin</message>
+	<message key="plugins.generic.pdfJsViewer.description"><![CDATA[Dieses Plugin benutzt den <a href="http://mozilla.github.io/pdf.js">pdf.js PDF viewer</a>, um PDFs auf den Fahnenseiten von Artikeln und Ausgaben anzuzeigen.]]></message>
 </locale>


### PR DESCRIPTION
The [main locale](https://github.com/pkp/ojs/blob/master/locale/de_DE/locale.xml) of ojs translates `plugin` as `Plugin` not as `Plug-In`.