### PR TITLE
pkp/pdfJsViewer#32: register hooks as last to fire

### DIFF
--- a/PdfJsViewerPlugin.inc.php
+++ b/PdfJsViewerPlugin.inc.php
@@ -21,8 +21,8 @@ class PdfJsViewerPlugin extends GenericPlugin {
 	function register($category, $path, $mainContextId = null) {
 		if (parent::register($category, $path, $mainContextId)) {
 			if ($this->getEnabled($mainContextId)) {
-				HookRegistry::register('ArticleHandler::view::galley', array($this, 'articleCallback'));
-				HookRegistry::register('IssueHandler::view::galley', array($this, 'issueCallback'));
+				HookRegistry::register('ArticleHandler::view::galley', array($this, 'articleCallback'), HOOK_SEQUENCE_LAST);
+				HookRegistry::register('IssueHandler::view::galley', array($this, 'issueCallback'), HOOK_SEQUENCE_LAST);
 				AppLocale::requireComponents(LOCALE_COMPONENT_APP_COMMON);
 			}
 			return true;


### PR DESCRIPTION
Move registration of `ArticleHander::view::galley` and `IssueHander::view::galley` as `HOOK_SEQUENCE_LAST` to allow other plugins early access to these hooks before this plugin finishes hook processing with the `return true`.