### PR TITLE
Use RESTful URL config for iframe URL

### DIFF
--- a/PdfJsViewerPlugin.inc.php
+++ b/PdfJsViewerPlugin.inc.php
@@ -67,6 +67,13 @@ class PdfJsViewerPlugin extends GenericPlugin {
 		$templateMgr = TemplateManager::getManager($request);
 		if ($galley && $galley->getFileType() == 'application/pdf') {
 			$application = Application::getApplication();
+
+			$journal = $request->getJournal();
+      $pdfUrl = $journal->getPath() . '/article/download/' . $article->getBestArticleId() . '/' . $galley->getBestGalleyId();
+      if (Config::getVar('general', 'restful_urls') != 'Off') {
+        $pdfUrl = '/index.php/' . $pdfUrl;
+      }	
+
 			$templateMgr->assign(array(
 				'displayTemplateResource' => $this->getTemplateResource('display.tpl'),
 				'pluginUrl' => $request->getBaseUrl() . '/' . $this->getPluginPath(),
@@ -76,6 +83,7 @@ class PdfJsViewerPlugin extends GenericPlugin {
 				'galley' => $galley,
 				'jQueryUrl' => $this->_getJQueryUrl($request),
 				'currentVersionString' => $application->getCurrentVersion()->getVersionString(false),
+				'pdfUrl' => $pdfUrl
 			));
 			$templateMgr->display($this->getTemplateResource('articleGalley.tpl'));
 			return true;

--- a/templates/articleGalley.tpl
+++ b/templates/articleGalley.tpl
@@ -7,6 +7,5 @@
  *
  * Embedded viewing of a PDF galley.
  *}
-{capture assign="pdfUrl"}{url op="download" path=$article->getBestArticleId($currentJournal)|to_array:$galley->getBestGalleyId($currentJournal):$galleyFile->getId() escape=false}{/capture}
 {capture assign="parentUrl"}{url page="article" op="view" path=$article->getBestArticleId($currentJournal)}{/capture}
 {include file=$displayTemplateResource title=$article->getLocalizedTitle() parentUrl=$parentUrl pdfUrl=$pdfUrl}


### PR DESCRIPTION
No longer use core's base URL remover, since it always remove /index.php/.
Use main config file's restful_urls setting variable to determine whether
/index.php/ is being utilized.