### PR TITLE
 Build encoded URL in JS instead of Smarty for the benefit of EZProxy

### DIFF
--- a/templates/display.tpl
+++ b/templates/display.tpl
@@ -48,8 +48,17 @@
 
 	</header>
 
+        <script type="text/javascript">
+            // Creating iframe src in JS instead of Smarty so that EZProxy installs can reliably do their rewrites.
+            $(document).ready(function() {ldelim}
+                var urlBase="{$pluginUrl}/pdf.js/web/viewer.html?file=";
+                var pdfUrl="{$pdfUrl}";
+                $("#pdfCanvasContainer > iframe").attr("src", urlBase + encodeURIComponent(pdfUrl));
+            {rdelim});
+        </script>
+
 	<div id="pdfCanvasContainer" class="galley_view">
-		<iframe src="{$pluginUrl}/pdf.js/web/viewer.html?file={$pdfUrl|escape:"url"}" width="100%" height="100%" style="min-height: 500px;" allowfullscreen webkitallowfullscreen></iframe>
+		<iframe src="" width="100%" height="100%" style="min-height: 500px;" allowfullscreen webkitallowfullscreen></iframe>
 	</div>
 	{call_hook name="Templates::Common::Footer::PageFooter"}
 </body>

--- a/templates/display.tpl
+++ b/templates/display.tpl
@@ -49,10 +49,10 @@
 	</header>
 
         <script type="text/javascript">
-            // Creating iframe src in JS instead of Smarty so that EZProxy installs can reliably do their rewrites.
+            // Creating iframe's src in JS instead of Smarty so that EZProxy-using sites can find our domain in $pdfUrl and do their rewrites on it.
             $(document).ready(function() {ldelim}
-                var urlBase="{$pluginUrl}/pdf.js/web/viewer.html?file=";
-                var pdfUrl="{$pdfUrl}";
+                var urlBase = "{$pluginUrl}/pdf.js/web/viewer.html?file=";
+                var pdfUrl = {$pdfUrl|json_encode|default:''};
                 $("#pdfCanvasContainer > iframe").attr("src", urlBase + encodeURIComponent(pdfUrl));
             {rdelim});
         </script>


### PR DESCRIPTION
One solution for #34.  EZProxy isn't able to transform a embedded URL-encoded variable. If we encode and build on the client-side, EZProxy can.